### PR TITLE
feat(frontend): integración auth con proxy, MSW opt-in y dashboard mínimo (phase1-5.5)

### DIFF
--- a/docs/development/DEVLOG.md
+++ b/docs/development/DEVLOG.md
@@ -3,6 +3,7 @@
 Este documento describe el proceso de desarrollo del proyecto **Optima**. Es un registro de las decisiones tomadas, los aprendizajes adquiridos, los problemas que surgieron y la forma en que se resolvieron, y el progreso realizado.
 
 ## 📑 Índice
+- [[2026-05-03] - Frontend | Sprint 5.5: Integración real de auth y proxy hacia la API](#2026-05-03---frontend--sprint-55-integración-real-de-auth-y-proxy-hacia-la-api)
 - [[2026-04-13] - Backend | Alembic y persistencia de auth sobre PostgreSQL](#2026-04-13---backend--alembic-y-persistencia-de-auth-sobre-postgresql)
 - [[2026-03-19] - Frontend | Sprint 5: Auth UI, Mocking & Protected Routes](#2026-03-19---frontend--sprint-5-auth-ui-mocking--protected-routes)
 - [[2026-03-18] - Backend | Sprint 2: Finalización de autenticación JWT](#2026-03-18---backend--sprint-2-finalización-de-autenticación-jwt)
@@ -11,6 +12,36 @@ Este documento describe el proceso de desarrollo del proyecto **Optima**. Es un 
 - [[2026-03-11] - Frontend | Sprint 1: Setup base y estabilización de componentes](#2026-03-11---frontend--sprint-1-setup-base-y-estabilización-de-componentes)
 - [[2026-03-11] - Backend | Sprint 1: Setup base y estrategia asíncrona](#2026-03-11---backend--sprint-1-setup-base-y-estrategia-asíncrona)
 - [[2026-02-16 - 2026-02-23] - Estrategia y documentación](#2026-02-16---2026-02-23---estrategia-y-documentación)
+
+---
+
+## [2026-05-03] - Frontend | Sprint 5.5: Integración real de auth y proxy hacia la API
+
+### Contexto y objetivos
+Cerrar el hito **phase1-5.5** del tablero: que el frontend consuma los endpoints reales de autenticación (`POST /api/v1/auth/login` y `POST /api/v1/auth/register`) según el contrato en `docs/api-contracts/auth.md`, con tráfico bajo el mismo origen en desarrollo (proxy en Next), MSW **opt-in** para no bloquear la API real, y una ruta de **dashboard** mínima que evite el 404 tras el inicio de sesión y permita cerrar la sesión local sin depender solo de las herramientas de desarrollo del navegador.
+
+### Implementación técnica
+- **Proxy de desarrollo:** `rewrites` en `frontend/next.config.ts` hacia `BACKEND_URL` (por defecto `http://127.0.0.1:8000`) para reenviar `/api/:path*` al FastAPI sin exponer la URL del API en el cliente mediante variables `NEXT_PUBLIC_*`.
+- **MSW condicionado:** `frontend/src/components/ui/providers/MSWProvider.tsx` arranca el worker solo si `NODE_ENV` es `development` y `NEXT_PUBLIC_ENABLE_MSW === 'true'`; uso de `finally` para no dejar la aplicación en blanco si el worker no se inicia.
+- **Dashboard mínimo:** `frontend/src/app/[locale]/dashboard/page.tsx` con acción **Cerrar sesión** que invalida la cookie `access_token` (`path=/`, `SameSite=Lax`) y redirige a `/auth/login`, alineado con `frontend/src/proxy.ts`.
+- **Registro real:** `frontend/src/components/ui/auth/RegisterForm.tsx` con `fetch` a `/api/v1/auth/register`, cuerpo JSON con `organization_name` mapeado desde `organizationName`, misma cookie y redirección al dashboard que el login.
+- **Mocks de registro:** `frontend/src/mocks/handlers.ts` con handler de `POST /api/v1/auth/register` (201, 400 para `already@mock.local`, 422 de validación) para pruebas locales con MSW activo; el handler de login sigue limitado al usuario de demo acordado.
+- **Errores de API unificados:** nuevo módulo `frontend/src/lib/api-errors.ts` con `formatFastApiDetail` para `detail` en **string** o **lista** (422); uso en `AuthForm.tsx` y `RegisterForm.tsx` con mensajes por defecto distintos.
+- **Calidad:** ejecución de `bun run lint` en `frontend/` antes de cada entrega en la rama de trabajo.
+
+### 💡 Repaso técnico: mismo origen, cookies y mocks
+El **rewrite** hace que el navegador siga hablando con `localhost:3000` mientras el proceso de Next reenvía `/api/...` al backend: se evita CORS en el navegador y se mantienen coherentes las cookies con `path=/`. **MSW** intercepta en el cliente antes de la red; por eso el flag explícito evita que un desarrollador crea estar probando la API real cuando el worker sigue activo. Los **handlers** imitan el JSON del contrato; no sustituyen la persistencia en PostgreSQL: el registro mock no “crea” usuario para el login mock salvo casos de prueba documentados (p. ej. credenciales fijas de login).
+
+### Problemas surgidos y cómo se abordaron
+- **`curl` devolvía `000`:** el servidor de Next no estaba en marcha o la URL no coincidía con el puerto del `next dev`.
+- **`ECONNREFUSED` al proxy:** el backend no escuchaba en `127.0.0.1:8000`; comportamiento esperado sin contenedor o proceso local del API.
+- **404 en `/es/dashboard`:** la ruta no existía aún; se añadió la página mínima y se explicó el rol de la cookie `access_token` con `proxy.ts` redirigiendo desde login cuando hay sesión.
+- **Confusión MSW vs API real:** se documentó en el equipo que `NEXT_PUBLIC_ENABLE_MSW=true` es solo para trabajo desacoplado; por defecto se prioriza la API real.
+- **Incógnito y MSW:** el modo privado puede interferir con el Service Worker; las pruebas de mock se validaron en ventana normal.
+
+### Próximos pasos
+- Prueba **extremo a extremo** con el backend y la base de datos levantados por el equipo (o entorno compartido) para validar registro y login contra datos persistidos.
+- Avanzar en **fase 2** del roadmap: `AuthContext`, refresh y cierre de sesión más formal, endpoint `/me`, cliente HTTP compartido si aplica, y reutilizar o alinear `frontend/src/lib/validations/auth.ts` con los formularios para evitar duplicar esquemas Zod.
 
 ---
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,8 +1,15 @@
+// Esta configuración permite que el frontend pueda comunicarse con el backend al puerto 8000
+
 import type { NextConfig } from "next";
 import createNextIntlPlugin from 'next-intl/plugin';
 
+// Aplica el plugin de internacionalización
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
+// Envía las peticiones de la API al backend
+const backendUrl = process.env.BACKEND_URL ?? 'http://127.0.0.1:8000';
+
+// Configuración de Next.js
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -13,6 +20,15 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // Reescribe las rutas de la API para que apunten al backend
+  rewrites: async () => [
+    {
+      source: '/api/:path*',
+      destination: `${backendUrl}/api/:path*`,
+    },
+  ],
 };
 
+
+  // Luego, se aplica el plugin de internacionalización y el proxy de la API
 export default withNextIntl(nextConfig);

--- a/frontend/src/app/[locale]/dashboard/page.tsx
+++ b/frontend/src/app/[locale]/dashboard/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRouter } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
+
+function clearAccessTokenCookie() {
+  document.cookie =
+    "access_token=; path=/; max-age=0; SameSite=Lax";
+}
+
+export default function DashboardPage() {
+  const router = useRouter();
+
+  const handleSignOut = () => {
+    clearAccessTokenCookie();
+    router.push("/auth/login");
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-6 bg-slate-50 p-4">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+          Panel
+        </h1>
+        <p className="text-sm text-muted-foreground max-w-md">
+          Vista mínima del panel. Aquí irá el contenido del dashboard en
+          iteraciones posteriores.
+        </p>
+      </div>
+      <Button type="button" variant="outline" onClick={handleSignOut}>
+        Cerrar sesión
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/auth/AuthForm.tsx
+++ b/frontend/src/components/ui/auth/AuthForm.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState } from 'react';
-import { Link, useRouter } from '@/i18n/navigation';
+import { useState } from "react";
+import { Link, useRouter } from "@/i18n/navigation";
 import Image from "next/image";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useTranslations } from "next-intl";
+import { formatFastApiDetail } from "@/lib/api-errors";
 
 export const AuthForm = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -14,10 +15,9 @@ export const AuthForm = () => {
   const router = useRouter();
   const t = useTranslations("Auth");
 
-  // Esquema de validación dinámico para traducir errores de Zod
   const loginSchema = z.object({
-    email: z.string().email(t('errors.invalid_email')),
-    password: z.string().min(1, t('errors.password_required')),
+    email: z.string().email(t("errors.invalid_email")),
+    password: z.string().min(1, t("errors.password_required")),
   });
 
   type LoginValues = z.infer<typeof loginSchema>;
@@ -39,9 +39,9 @@ export const AuthForm = () => {
     setServerError(null);
 
     try {
-      const response = await fetch('/api/v1/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch("/api/v1/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
       });
 
@@ -49,9 +49,14 @@ export const AuthForm = () => {
 
       if (response.ok) {
         document.cookie = `access_token=${result.access_token}; path=/; max-age=86400; SameSite=Lax`;
-        router.push('/dashboard');
+        router.push("/dashboard");
       } else {
-        setServerError(result.detail || "Credenciales inválidas");
+        setServerError(
+          formatFastApiDetail(
+            result?.detail,
+            "Credenciales inválidas",
+          ),
+        );
       }
     } catch {
       setServerError("Error de conexión");
@@ -64,17 +69,17 @@ export const AuthForm = () => {
     <div className="max-w-md w-full bg-card text-card-foreground border border-border rounded-xl shadow-sm p-8 font-sans">
       <header className="mb-8">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-          {t('login_title')}
+          {t("login_title")}
         </h1>
         <p className="text-sm text-muted-foreground mt-2">
-          {t('login_subtitle')}
+          {t("login_subtitle")}
         </p>
       </header>
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <div className="space-y-2">
           <label htmlFor="email" className="text-sm font-medium text-foreground">
-            {t('email_label')}
+            {t("email_label")}
           </label>
           <input
             id="email"
@@ -95,7 +100,7 @@ export const AuthForm = () => {
 
         <div className="space-y-2">
           <label htmlFor="password" className="text-sm font-medium text-foreground">
-            {t('password_label')}
+            {t("password_label")}
           </label>
           <input
             id="password"
@@ -125,7 +130,7 @@ export const AuthForm = () => {
           disabled={isLoading}
           className="w-full h-10 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:bg-slate-300 disabled:opacity-50"
         >
-          {isLoading ? t('logging_in') : t('login_button')}
+          {isLoading ? t("logging_in") : t("login_button")}
         </button>
 
         <div className="flex items-center justify-between">
@@ -136,11 +141,11 @@ export const AuthForm = () => {
               className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
             />
             <label htmlFor="remember" className="text-sm text-muted-foreground">
-              {t('remember_me')}
+              {t("remember_me")}
             </label>
           </div>
           <Link href="#" className="text-sm font-medium text-primary hover:underline">
-            {t('forgot_password')}
+            {t("forgot_password")}
           </Link>
         </div>
 
@@ -149,22 +154,22 @@ export const AuthForm = () => {
             <span className="w-full border-t border-border" />
           </div>
           <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-card px-2 text-muted-foreground font-inter">{t('continue_with')}</span>
+            <span className="bg-card px-2 text-muted-foreground font-inter">{t("continue_with")}</span>
           </div>
         </div>
 
-        <button 
+        <button
           type="button"
           className="w-full inline-flex justify-center items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 transition-all"
         >
           <Image src="https://www.google.com/favicon.ico" alt="Google" width={16} height={16} />
-          {t('google_account')}
+          {t("google_account")}
         </button>
 
         <div className="mt-8 text-center text-sm text-muted-foreground">
-          {t('no_account')}{" "}
+          {t("no_account")}{" "}
           <Link href="/auth/register" className="font-semibold text-primary hover:underline">
-            {t('register_link')}
+            {t("register_link")}
           </Link>
         </div>
       </form>

--- a/frontend/src/components/ui/auth/RegisterForm.tsx
+++ b/frontend/src/components/ui/auth/RegisterForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from 'react';
-import { Link } from '@/i18n/navigation';
+import { useState } from "react";
+import { Link, useRouter } from "@/i18n/navigation";
 import Image from "next/image";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -11,17 +11,19 @@ import { useTranslations } from "next-intl";
 export const RegisterForm = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
+  const router = useRouter();
   const t = useTranslations("Register");
 
-  // Definimos el esquema aquí dentro para usar las traducciones de 't'
-  const registerSchema = z.object({
-    organizationName: z.string().min(2),
-    email: z.string().email(),
-    password: z.string().min(8),
-    confirmPassword: z.string()
-  }).refine((data) => data.password === data.confirmPassword, {
-    path: ["confirmPassword"],
-  });
+  const registerSchema = z
+    .object({
+      organizationName: z.string().min(2),
+      email: z.string().email(),
+      password: z.string().min(8),
+      confirmPassword: z.string(),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      path: ["confirmPassword"],
+    });
 
   type RegisterValues = z.infer<typeof registerSchema>;
 
@@ -39,33 +41,62 @@ export const RegisterForm = () => {
     },
   });
 
+  const formatApiDetail = (detail: unknown): string => {
+    if (typeof detail === "string") return detail;
+    if (Array.isArray(detail)) {
+      return detail
+        .map((item) =>
+          typeof item === "object" && item !== null && "msg" in item
+            ? String((item as { msg: string }).msg)
+            : JSON.stringify(item),
+        )
+        .join(" ");
+    }
+    return "No se pudo completar el registro";
+  };
+
   const onSubmit = async (data: RegisterValues) => {
     setIsLoading(true);
     setServerError(null);
 
-    setTimeout(() => {
-      if (data.password === "12345678") { 
-        setServerError("Contraseña demasiado común");
-        setIsLoading(false);
+    try {
+      const response = await fetch("/api/v1/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: data.email,
+          password: data.password,
+          organization_name: data.organizationName,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        document.cookie = `access_token=${result.access_token}; path=/; max-age=86400; SameSite=Lax`;
+        router.push("/dashboard");
       } else {
-        setIsLoading(false);
-        alert("Cuenta creada con éxito");
+        setServerError(formatApiDetail(result?.detail));
       }
-    }, 1000);
+    } catch {
+      setServerError("Error de conexión");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
     <div className="max-w-md w-full bg-card text-card-foreground border border-border rounded-xl shadow-sm p-8 font-sans">
       <header className="mb-8">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-          {t('title')}
+          {t("title")}
         </h1>
       </header>
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <div className="space-y-2">
           <label htmlFor="email" className="text-sm font-medium text-foreground">
-            {t('email_label')}
+            {t("email_label")}
           </label>
           <input
             id="email"
@@ -80,7 +111,7 @@ export const RegisterForm = () => {
 
         <div className="space-y-2">
           <label htmlFor="organizationName" className="text-sm font-medium text-foreground">
-            {t('org_name_label')}
+            {t("org_name_label")}
           </label>
           <input
             id="organizationName"
@@ -95,7 +126,7 @@ export const RegisterForm = () => {
 
         <div className="space-y-2">
           <label htmlFor="password" className="text-sm font-medium text-foreground">
-            {t('password_label')}
+            {t("password_label")}
           </label>
           <input
             id="password"
@@ -110,7 +141,7 @@ export const RegisterForm = () => {
 
         <div className="space-y-2">
           <label htmlFor="confirmPassword" className="text-sm font-medium text-foreground">
-            {t('confirm_password_label')}
+            {t("confirm_password_label")}
           </label>
           <input
             id="confirmPassword"
@@ -135,14 +166,14 @@ export const RegisterForm = () => {
           disabled={isLoading}
           className="w-full h-10 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:bg-slate-300 disabled:opacity-50"
         >
-          {isLoading ? t('submitting') : t('submit_button')}
+          {isLoading ? t("submitting") : t("submit_button")}
         </button>
       </form>
 
       <div className="mt-6 text-center text-sm text-muted-foreground font-sans">
-        {t('have_account')}{" "}
+        {t("have_account")}{" "}
         <Link href="/auth/login" className="text-primary hover:underline font-medium transition-colors">
-          {t('login_link')}
+          {t("login_link")}
         </Link>
       </div>
 
@@ -151,16 +182,16 @@ export const RegisterForm = () => {
           <span className="w-full border-t border-border" />
         </div>
         <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-card px-2 text-muted-foreground">{t('register_with')}</span>
+          <span className="bg-card px-2 text-muted-foreground">{t("register_with")}</span>
         </div>
       </div>
 
-      <button 
+      <button
         type="button"
         className="w-full inline-flex justify-center items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 transition-all"
       >
         <Image src="https://www.google.com/favicon.ico" alt="Google" width={16} height={16} />
-        {t('google_account')}
+        {t("google_account")}
       </button>
     </div>
   );

--- a/frontend/src/components/ui/auth/RegisterForm.tsx
+++ b/frontend/src/components/ui/auth/RegisterForm.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useTranslations } from "next-intl";
+import { formatFastApiDetail } from "@/lib/api-errors";
 
 export const RegisterForm = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -41,20 +42,6 @@ export const RegisterForm = () => {
     },
   });
 
-  const formatApiDetail = (detail: unknown): string => {
-    if (typeof detail === "string") return detail;
-    if (Array.isArray(detail)) {
-      return detail
-        .map((item) =>
-          typeof item === "object" && item !== null && "msg" in item
-            ? String((item as { msg: string }).msg)
-            : JSON.stringify(item),
-        )
-        .join(" ");
-    }
-    return "No se pudo completar el registro";
-  };
-
   const onSubmit = async (data: RegisterValues) => {
     setIsLoading(true);
     setServerError(null);
@@ -76,7 +63,12 @@ export const RegisterForm = () => {
         document.cookie = `access_token=${result.access_token}; path=/; max-age=86400; SameSite=Lax`;
         router.push("/dashboard");
       } else {
-        setServerError(formatApiDetail(result?.detail));
+        setServerError(
+          formatFastApiDetail(
+            result?.detail,
+            "No se pudo completar el registro",
+          ),
+        );
       }
     } catch {
       setServerError("Error de conexión");

--- a/frontend/src/components/ui/providers/MSWProvider.tsx
+++ b/frontend/src/components/ui/providers/MSWProvider.tsx
@@ -7,19 +7,22 @@ export function MSWProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const initMSW = async () => {
-      // Solo activa MSW en desarrollo
-      if (process.env.NODE_ENV === 'development') {
-        const { worker } = await import('@/mocks/browser');
-        // 'bypass' permite que las peticiones que NO están en handlers sigan su curso normal
-        await worker.start({ onUnhandledRequest: 'bypass' });
+      const enableMsw = process.env.NEXT_PUBLIC_ENABLE_MSW === 'true';
+
+      try {
+        if (process.env.NODE_ENV === 'development' && enableMsw) {
+          const { worker } = await import('@/mocks/browser');
+          await worker.start({ onUnhandledRequest: 'bypass' });
+        }
+      } finally {
+        setMswReady(true);
       }
-      setMswReady(true);
     };
 
-    initMSW();
+    void initMSW();
   }, []);
 
-  if (!mswReady) return null; // Previene fallos visuales/hidratación hasta que MSW cargue
+  if (!mswReady) return null;
 
   return <>{children}</>;
 }

--- a/frontend/src/lib/api-errors.ts
+++ b/frontend/src/lib/api-errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Convierte el campo `detail` típico de errores HTTP de FastAPI en un mensaje legible.
+ * Acepta `detail` como string (401, 400, …) o lista de validación (422).
+ */
+export function formatFastApiDetail(detail: unknown, fallback: string): string {
+    if (typeof detail === "string" && detail.trim().length > 0) {
+      return detail;
+    }
+  
+    if (Array.isArray(detail)) {
+      const parts = detail.flatMap((item) => {
+        if (typeof item === "string") return [item];
+        if (typeof item === "object" && item !== null) {
+          const row = item as Record<string, unknown>;
+          if (typeof row.msg === "string") return [row.msg];
+          if (typeof row.message === "string") return [row.message];
+        }
+        return [];
+      });
+      if (parts.length > 0) {
+        return parts.join(" ");
+      }
+    }
+  
+    return fallback;
+  }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -28,5 +28,88 @@ export const handlers = [
       { detail: "Credenciales inválidas" }, 
       { status: 401 }
     );
-  })
+  }),
+
+  http.post('/api/v1/auth/register', async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    const email = typeof body.email === 'string' ? body.email : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+    const organization_name =
+      typeof body.organization_name === 'string' ? body.organization_name : '';
+
+    if (!email || !password || !organization_name) {
+      return HttpResponse.json(
+        {
+          detail: [
+            {
+              type: 'missing',
+              loc: ['body'],
+              msg: 'Campos obligatorios: email, password, organization_name',
+            },
+          ],
+        },
+        { status: 422 },
+      );
+    }
+
+    if (password.length < 8) {
+      return HttpResponse.json(
+        {
+          detail: [
+            {
+              type: 'value_error',
+              loc: ['body', 'password'],
+              msg: 'La contraseña debe tener al menos 8 caracteres',
+            },
+          ],
+        },
+        { status: 422 },
+      );
+    }
+
+    if (organization_name.length < 2) {
+      return HttpResponse.json(
+        {
+          detail: [
+            {
+              type: 'value_error',
+              loc: ['body', 'organization_name'],
+              msg: 'El nombre de la organización es demasiado corto',
+            },
+          ],
+        },
+        { status: 422 },
+      );
+    }
+
+    // Misma idea que el backend: 400 si el email ya existe (caso de prueba fijo)
+    if (email === 'already@mock.local') {
+      return HttpResponse.json(
+        { detail: 'Email already registered' },
+        { status: 400 },
+      );
+    }
+
+    const createdAt = new Date().toISOString();
+
+    return HttpResponse.json(
+      {
+        access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.dummy.register',
+        token_type: 'bearer',
+        user: {
+          id: 99,
+          email,
+          organization_id: 99,
+          role: 'admin',
+          created_at: createdAt,
+        },
+        organization: {
+          id: 99,
+          name: organization_name,
+          created_at: createdAt,
+        },
+      },
+      { status: 201 },
+    );
+  }),
 ]

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,4 +1,4 @@
-/// Filtro de Seguridad e Idioma
+/// Esquema de Control de Acceso Basado en Rutas (RBAC Ligero) con Persistencia de Sesión y Prefijos de Idioma - Filtro de Seguridad e Idioma
 // Verifica si la página es para todos o solo para miembros - Revisa el "carnet" (token) en las cookies - Entrega la página en el idioma que pediste
 
 import createMiddleware from 'next-intl/middleware';


### PR DESCRIPTION
## Resumen
Integración del frontend con la API de autenticación bajo `/api/v1/auth` mediante **rewrites** en Next, **MSW** solo cuando se solicita por variable de entorno, **registro** conectado al mismo flujo que login (cookie + redirección), **dashboard** mínima con cierre de sesión local, **handler MSW** de registro para consistencia con login, y **mensajes de error** unificados para respuestas FastAPI (`detail` string o lista).

## Cambios principales
| Área | Archivos / notas |
|------|------------------|
| Proxy dev | `frontend/next.config.ts` — `BACKEND_URL`, `rewrites` `/api/:path*` |
| MSW | `frontend/src/components/ui/providers/MSWProvider.tsx` — `NEXT_PUBLIC_ENABLE_MSW` |
| Dashboard | `frontend/src/app/[locale]/dashboard/page.tsx` — placeholder + borrado de cookie |
| Registro | `frontend/src/components/ui/auth/RegisterForm.tsx` — `POST .../register`, mapeo `organization_name` |
| Mocks | `frontend/src/mocks/handlers.ts` — `POST .../register` (201/400/422) |
| Errores API | `frontend/src/lib/api-errors.ts` — `formatFastApiDetail`; uso en `AuthForm.tsx` y `RegisterForm.tsx` |

## Cómo probar (revisor)
1. Copiar variables necesarias en `frontend/.env.local` (`BACKEND_URL`, opcional `NEXT_PUBLIC_ENABLE_MSW`).
2. **Sin BE:** `NEXT_PUBLIC_ENABLE_MSW=false` → login/register deben fallar con error de conexión o según proxy; no debe interceptar MSW.
3. **Solo FE con mock:** `NEXT_PUBLIC_ENABLE_MSW=true` → login con credenciales de demo del handler; registro con datos válidos y **no** usar `already@mock.local` para 201; `already@mock.local` para 400.
4. **Con BE:** `MSW=false`, API en `:8000` → flujo real y persistencia en base según backend.
5. Tras login o registro exitoso: debe cargarse `/[locale]/dashboard`; **Cerrar sesión** debe permitir volver a `/auth/login` sin bucle 404.

## Fuera de alcance
- No se modifica documentación de producto en este PR salvo esta entrada de DEVLOG si el equipo la incluye en el mismo merge.
- Refresh token, `/me`, `AuthContext` y CORS en FastAPI quedan para iteraciones posteriores del roadmap.

## Checklist
- [ ] Revisión de seguridad: ningún secreto en archivos versionados (solo `.env.local` local, ignorado).
- [ ] Comportamiento por defecto = API real (MSW desactivado si no se define el flag).
- [ ] PR enlazado al issue **phase1-5.5** / número correspondiente en GitHub.

## Relacionado
- Issue / hito: **phase1-5.5** (integración FE–BE auth).